### PR TITLE
vimrc中存在重复配置导致使用vim时报警告

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -39,7 +39,6 @@ Bundle 'Lokaltog/vim-powerline'
 " 配色
 Bundle 'altercation/vim-colors-solarized'
 Bundle 'stephenmckinney/vim-solarized-powerline'
-Bundle 'altercation/vim-colors-solarized'
 
 " vim-scripts repos
 Bundle 'L9'


### PR DESCRIPTION
vimrc中85行与87行重复，导致使用vim时会报出警告信息，按任意键才可以继续
